### PR TITLE
Return error message if input file not found

### DIFF
--- a/tools/Runtime Condenser/Main.cpp
+++ b/tools/Runtime Condenser/Main.cpp
@@ -145,8 +145,8 @@ bool readFromFile() {
 		if(!runQuiet) {
 			cout << "Error: Missing file 'Input.txt'\n";
 			cout << "Check the name if your file system is Case Sensitive\n";
-			return false;
-		}	
+		}
+		return false;
 	}
 	//Open file to read
 	FILE * inputFile = fopen("Input.txt", "r");

--- a/tools/Runtime Condenser/Main.cpp
+++ b/tools/Runtime Condenser/Main.cpp
@@ -140,6 +140,14 @@ inline void printprogressbar(unsigned short progress /*as percent*/) {
 }
 
 bool readFromFile() {
+	std::ifstream ifile("Input.txt");
+	if(!(bool)ifile) {
+		if(!runQuiet) {
+			cout << "Error: Missing file 'Input.txt'\n";
+			cout << "Check the name if your file system is Case Sensitive\n";
+			return false;
+		}	
+	}
 	//Open file to read
 	FILE * inputFile = fopen("Input.txt", "r");
 


### PR DESCRIPTION
on Linux you just got a Segmentation Fault without this check, it's also useful for case sensitive file system owners to know that case is an issue
