### PR TITLE
Baymerge Meteor Fixes

### DIFF
--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -17,7 +17,7 @@
 /datum/game_mode/meteor/process()
 	if(world.time >= next_wave)
 		next_wave = world.time + meteor_wave_delay
-		spawn() spawn_meteors(6, meteors_normal)
+		spawn() spawn_meteors(6)
 
 /datum/game_mode/meteor/declare_completion()
 	var/text

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -4,19 +4,6 @@
 /var/const/meteors_in_wave = 50
 /var/const/meteors_in_small_wave = 10
 
-/proc/meteor_wave(var/number = meteors_in_wave)
-	if (number == 0)
-		return
-
-	if(!ticker || wavesecret)
-		return
-
-	wavesecret = 1
-	for(var/i = 0 to number)
-		spawn(rand(10,100))
-			spawn_meteor()
-	spawn(meteor_wave_delay)
-		wavesecret = 0
 
 /proc/spawn_meteors(var/number = meteors_in_small_wave)
 	for(var/i = 0; i < number; i++)

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -92,3 +92,4 @@
 /proc/event_meteor_wave(var/number = meteors_in_wave)
 	for(var/i = 0 to number)
 		spawn(rand(10,80))
+			spawn_meteor()


### PR DESCRIPTION
I don't think ive done pushing correctly, this PR took 10 minutes to push to remove which definitely seems wrong

In any case, fixes four compile errors related to meteors in the baymerge PR, and also fixes meteor events - A single line had been removed which would cause meteors to not spawn.

I removed a defunct function from one of the meteor files, because its no longer referenced or needed anywhere in live code, and its the only place the now-removed wavesecret var was being referenced.

No idea why meteor.dm was trying to pass two vars into the spawn_meteors proc, since afaik its never taken more than one input, and the variable it was trying to pass in doesn't exist. I reverted it back to our normal behaviour, passing in a value of 6, although this doesn't seem correct either, it is at least what we currently have and thus not a change
