### PR TITLE
Istype

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -2,6 +2,7 @@
 #define CLAMP01(x) 		(Clamp(x, 0, 1))
 
 #define isAI(A) istype(A, /mob/living/silicon/ai)
+#define isDrone(A) istype(A, /mob/living/silicon/robot/drone)
 
 #define isalien(A) istype(A, /mob/living/carbon/alien)
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -182,7 +182,7 @@ Works together with spawning an observer, noted above.
 		//It is also set in the mob/death proc
 		if (isanimal(src))
 			set_death_time(ANIMAL, world.time)
-		else if (ispAI(src) || isdrone(src))
+		else if (ispAI(src) || isDrone(src))
 			set_death_time(MINISYNTH, world.time)
 		else
 			set_death_time(CREW, world.time)//Crew is the fallback

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -82,7 +82,7 @@
 	timeofdeath = world.time
 	if (isanimal(src))
 		set_death_time(ANIMAL, world.time)
-	else if (ispAI(src) || isdrone(src))
+	else if (ispAI(src) || isDrone(src))
 		set_death_time(MINISYNTH, world.time)
 	else if (isliving(src))
 		set_death_time(CREW, world.time)//Crew is the fallback

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -30,6 +30,44 @@
 /mob/living/carbon/human/isMonkey()
 	return istype(species, /datum/species/monkey)
 
+
+/proc/ishuman_species(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Human"))
+		return 1
+	return 0
+
+/proc/isunathi(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Unathi"))
+		return 1
+	return 0
+
+/proc/istajara(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Tajara"))
+		return 1
+	return 0
+
+/proc/isskrell(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Skrell"))
+		return 1
+	return 0
+
+/proc/isvaurca(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Vaurca"))
+		return 1
+	return 0
+
+/proc/isipc(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Machine"))
+		return 1
+	return 0
+
+/proc/isvox(A)
+	if(istype(A, /mob/living/carbon/human) && (A:get_species() == "Vox"))
+		return 1
+	return 0
+
+
+
 /mob/proc/is_diona()
 	//returns which type of diona we are, or zero
 	if (istype(src, /mob/living/carbon/human))


### PR DESCRIPTION
Fixes a couple of is<type> errors with missing functions.
Added isDrone as macro

restored the various is<species> non macro functions. i don't know how or if they could be macro-ized